### PR TITLE
Adding optional cloudflare ai gateway refrence

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,1 +1,3 @@
 OPENAI_API_KEY=sk-proj-1234567890
+# Optional - Cloudflare AI Gateway https://developers.cloudflare.com/ai-gateway/
+# GATEWAY_BASE_URL=https://gateway.ai.cloudflare.com/v1/..

--- a/src/server.ts
+++ b/src/server.ts
@@ -53,6 +53,12 @@ export class Chat extends AIChatAgent<Env> {
             apiKey: this.env.OPENAI_API_KEY,
           });
 
+          // Cloudflare AI Gateway
+          // const openai = createOpenAI({
+          //   apiKey: this.env.OPENAI_API_KEY,
+          //   baseURL: this.env.GATEWAY_BASE_URL,
+          // });
+
           // Stream the AI response using GPT-4
           const result = streamText({
             model: openai("gpt-4o-2024-11-20"),


### PR DESCRIPTION
Its great because people behind a corporate proxy can bypass openai being blocked, and promotes ai gateway whereby you get a lot more insight into ai usage.

Also happy for it to be rejected but think its a good opportunity to call our ai gateway