### PR TITLE
Correct chat messages to use correct date

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -245,7 +245,9 @@ export default function Chat() {
                                     isUser ? "text-right" : "text-left"
                                   }`}
                                 >
-                                  {formatTime(new Date())}
+                                  {formatTime(
+                                    new Date(m.createdAt as unknown as string)
+                                  )}
                                 </p>
                               </div>
                             );


### PR DESCRIPTION
Self-explanatory, this was just bothering me as the message date would be updated to NOW whenever you reloaded the page (given they persist).