### PR TITLE
fix windows `npm run deploy` issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "start": "vite dev",
-    "deploy": "rm -rf dist && vite build && wrangler deploy",
+    "deploy": "vite build && wrangler deploy",
     "test": "vitest"
   },
   "keywords": [


### PR DESCRIPTION
Hi team,

When I run `npm run deploy` in Windows, I get an error saying the `rm` command is not found. I think the `rm` command is unnecessary because, by default, `vite build` already clears the dist folder. See: https://vite.dev/config/build-options.html#build-emptyoutdir

Thanks!