### PR TITLE
Specify @ai-sdk/ui-utils dependency 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@ai-sdk/openai": "^1.1.14",
         "@ai-sdk/react": "^1.1.18",
+        "@ai-sdk/ui-utils": "^1.1.16",
         "agents-sdk": "^0.0.22",
         "ai": "^4.1.46",
         "react": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@ai-sdk/openai": "^1.1.14",
     "@ai-sdk/react": "^1.1.18",
+    "@ai-sdk/ui-utils": "^1.1.16",
     "agents-sdk": "^0.0.22",
     "ai": "^4.1.46",
     "react": "^19.0.0",


### PR DESCRIPTION
Fixes #10 

***

Adds `@ai-sdk/ui-utils` dependency in the package.json (and lockfile) resolve an issue where `pnpm start` failed upon initial clone. 