### PR TITLE
Add clsx as dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "agents-sdk": "^0.0.22",
         "ai": "^4.1.47",
         "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
         "lucide-react": "^0.477.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "agents-sdk": "^0.0.22",
     "ai": "^4.1.47",
     "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
     "lucide-react": "^0.477.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",


### PR DESCRIPTION
`pnpm start` fails because the repo needs to specify `clsx` as one of its dependencies (npm is able to resolve it because it's a dependency of `class-variance-authority`)

Fixes #17 