### PR TITLE
fix: simplfy scheduleTask `when` type for Google compatibility

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -37,7 +37,7 @@ const scheduleTask = tool({
     "schedule a task to be executed at a later time. 'when' can be a date, a delay in seconds, or a cron pattern.",
   parameters: z.object({
     type: z.enum(["scheduled", "delayed", "cron"]),
-    when: z.union([z.number(), z.string()]),
+    when: z.string(),
     payload: z.string(),
   }),
   execute: async ({ type, when, payload }) => {


### PR DESCRIPTION
When using Google models, the chat doesn't respond with the example tools.

Google Generative AI only supports a limited set of schema fields https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/control-generated-output#fields. It doesn't work with `zod.union` or `zod.record`. `z.string().or(z.number())` as a replacement for `z.union` also doesn't work.

This update allows the template to work out of the box with Google models.

Fixes #20 