### PR TITLE
Remove type error console.log from tools.ts

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -46,7 +46,6 @@ const scheduleTask = tool({
     if (!agent) {
       throw new Error("No agent found");
     }
-    console.log(agent.env.OPENAI_API_KEY);
     try {
       agent.schedule(
         type === "scheduled"


### PR DESCRIPTION
We probably don't want random `console.log`s, but additionally this is an invalid access of a protected property `env` on `agent`.