### PR TITLE
Specify HTMLSelectElement type for onPointerDown event in Select component

### DIFF
--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -26,7 +26,7 @@ export const Select = ({
 
   return (
     <select
-      onPointerDown={(e: React.PointerEvent) => {
+      onPointerDown={(e: React.PointerEvent<HTMLSelectElement>) => {
         if (e.pointerType === "mouse") {
           setIsPointer(true);
         }


### PR DESCRIPTION
# Type Enhancement for Select Component's Pointer Event Handling

## Changes Made
- Updated the type annotation for the `onPointerDown` event handler in `Select.tsx`
- Changed `React.PointerEvent` to `React.PointerEvent<HTMLSelectElement>` to provide more specific typing

## Why
This change improves type safety by explicitly specifying that the pointer event is occurring on an HTML select element. The more specific type annotation:
- Provides better TypeScript type checking
- Enables better IDE autocompletion
- Makes the code more maintainable by clearly documenting the expected event target type

## Impact
This is a type-level change only and has no runtime impact on the application. It helps catch potential type-related bugs during development and improves code documentation.

## Testing
No additional testing required as this is a TypeScript type enhancement only.