### PR TITLE
fix: prevent submit on Enter key during composition in Chat component

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -370,7 +370,11 @@ export default function Chat() {
                 value={agentInput}
                 onChange={handleAgentInputChange}
                 onKeyDown={(e) => {
-                  if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
+                  if (
+                    e.key === "Enter" &&
+                    !e.shiftKey &&
+                    !e.nativeEvent.isComposing
+                  ) {
                     e.preventDefault();
                     handleAgentSubmit(e as unknown as React.FormEvent);
                   }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -370,7 +370,7 @@ export default function Chat() {
                 value={agentInput}
                 onChange={handleAgentInputChange}
                 onKeyDown={(e) => {
-                  if (e.key === "Enter" && !e.shiftKey) {
+                  if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
                     e.preventDefault();
                     handleAgentSubmit(e as unknown as React.FormEvent);
                   }


### PR DESCRIPTION
## Overview
Fixed an issue where pressing Enter during IME composition (when typing Japanese, Chinese, etc.) would prematurely submit the message form.

## Changes
Added a check for the `isComposing` flag in the `onKeyDown` event handler to prevent form submission when the user is in the middle of IME composition.

## Verification

You can verify the fix in these videos:
- Before:

https://github.com/user-attachments/assets/663f2526-6cb7-429d-bd8b-4e48e46f20c2

- After

https://github.com/user-attachments/assets/030802f3-baa4-46bf-bd5c-bc1e6c232938

## Technical Details
The fix leverages the `nativeEvent.isComposing` property which is `true` during IME composition, preventing the Enter key from triggering submission until composition is complete.