### PR TITLE
MCP tool call indication

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -263,44 +263,47 @@ export default function Chat() {
                           if (part.type === "tool-invocation") {
                             const toolInvocation = part.toolInvocation;
                             const toolCallId = toolInvocation.toolCallId;
+                            const needsConfirmation = toolsRequiringConfirmation.includes(
+                              toolInvocation.toolName as keyof typeof tools
+                            );
 
-                            if (
-                              toolsRequiringConfirmation.includes(
-                                toolInvocation.toolName as keyof typeof tools
-                              ) &&
-                              toolInvocation.state === "call"
-                            ) {
-                              return (
-                                <Card
-                                  // biome-ignore lint/suspicious/noArrayIndexKey: it's fine here
-                                  key={i}
-                                  className="p-4 my-3 rounded-md bg-neutral-100 dark:bg-neutral-900"
-                                >
-                                  <div className="flex items-center gap-2 mb-3">
-                                    <div className="bg-[#F48120]/10 p-1.5 rounded-full">
-                                      <Robot
-                                        size={16}
-                                        className="text-[#F48120]"
-                                      />
-                                    </div>
-                                    <h4 className="font-medium">
-                                      {toolInvocation.toolName}
-                                    </h4>
+                            return (
+                              <Card
+                                // biome-ignore lint/suspicious/noArrayIndexKey: it's fine here
+                                key={i}
+                                className={`p-4 my-3 rounded-md bg-neutral-100 dark:bg-neutral-900 ${
+                                  needsConfirmation ? "" : "border-[#F48120]/30"
+                                }`}
+                              >
+                                <div className="flex items-center gap-2 mb-3">
+                                  <div className={`${needsConfirmation ? "bg-[#F48120]/10" : "bg-[#F48120]/5"} p-1.5 rounded-full`}>
+                                    <Robot
+                                      size={16}
+                                      className="text-[#F48120]"
+                                    />
                                   </div>
+                                  <h4 className="font-medium">
+                                    {toolInvocation.toolName}
+                                    {!needsConfirmation && toolInvocation.state === "result" && (
+                                      <span className="ml-2 text-xs text-[#F48120]/70">✓ Completed</span>
+                                    )}
+                                  </h4>
+                                </div>
 
-                                  <div className="mb-3">
-                                    <h5 className="text-xs font-medium mb-1 text-muted-foreground">
-                                      Arguments:
-                                    </h5>
-                                    <pre className="bg-background/80 p-2 rounded-md text-xs overflow-auto">
-                                      {JSON.stringify(
-                                        toolInvocation.args,
-                                        null,
-                                        2
-                                      )}
-                                    </pre>
-                                  </div>
+                                <div className="mb-3">
+                                  <h5 className="text-xs font-medium mb-1 text-muted-foreground">
+                                    Arguments:
+                                  </h5>
+                                  <pre className="bg-background/80 p-2 rounded-md text-xs overflow-auto">
+                                    {JSON.stringify(
+                                      toolInvocation.args,
+                                      null,
+                                      2
+                                    )}
+                                  </pre>
+                                </div>
 
+                                {needsConfirmation && toolInvocation.state === "call" && (
                                   <div className="flex gap-2 justify-end">
                                     <Button
                                       variant="primary"
@@ -329,10 +332,24 @@ export default function Chat() {
                                       </Button>
                                     </Tooltip>
                                   </div>
-                                </Card>
-                              );
-                            }
-                            return null;
+                                )}
+
+                                {!needsConfirmation && toolInvocation.state === "result" && (
+                                  <div className="mt-3 border-t border-[#F48120]/10 pt-3">
+                                    <h5 className="text-xs font-medium mb-1 text-muted-foreground">
+                                      Result:
+                                    </h5>
+                                    <pre className="bg-background/80 p-2 rounded-md text-xs overflow-auto">
+                                      {JSON.stringify(
+                                        toolInvocation.result,
+                                        null,
+                                        2
+                                      )}
+                                    </pre>
+                                  </div>
+                                )}
+                              </Card>
+                            );
                           }
                           return null;
                         })}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -278,17 +278,17 @@ export default function Chat() {
                                   needsConfirmation ? "" : "border-[#F48120]/30"
                                 } max-h-[200px] overflow-y-auto`}
                               >
-                                <div className="flex items-center gap-2 mb-3 sticky top-0 bg-neutral-100 dark:bg-neutral-900 py-1">
-                                  <div className={`${needsConfirmation ? "bg-[#F48120]/10" : "bg-[#F48120]/5"} p-1.5 rounded-full`}>
+                                <div className="flex items-center gap-2 mb-3">
+                                  <div className={`${needsConfirmation ? "bg-[#F48120]/10" : "bg-[#F48120]/5"} p-1.5 rounded-full flex-shrink-0`}>
                                     <Robot
                                       size={16}
                                       className="text-[#F48120]"
                                     />
                                   </div>
-                                  <h4 className="font-medium">
+                                  <h4 className="font-medium flex items-center gap-2">
                                     {toolInvocation.toolName}
                                     {!needsConfirmation && toolInvocation.state === "result" && (
-                                      <span className="ml-2 text-xs text-[#F48120]/70">✓ Completed</span>
+                                      <span className="text-xs text-[#F48120]/70">✓ Completed</span>
                                     )}
                                   </h4>
                                 </div>

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -274,11 +274,11 @@ export default function Chat() {
                               <Card
                                 // biome-ignore lint/suspicious/noArrayIndexKey: it's fine here
                                 key={i}
-                                className={`p-4 my-3 rounded-md bg-neutral-100 dark:bg-neutral-900 ${
+                                className={`p-4 my-3 w-full max-w-[500px] rounded-md bg-neutral-100 dark:bg-neutral-900 ${
                                   needsConfirmation ? "" : "border-[#F48120]/30"
-                                }`}
+                                } max-h-[200px] overflow-y-auto`}
                               >
-                                <div className="flex items-center gap-2 mb-3">
+                                <div className="flex items-center gap-2 mb-3 sticky top-0 bg-neutral-100 dark:bg-neutral-900 py-1">
                                   <div className={`${needsConfirmation ? "bg-[#F48120]/10" : "bg-[#F48120]/5"} p-1.5 rounded-full`}>
                                     <Robot
                                       size={16}
@@ -297,7 +297,7 @@ export default function Chat() {
                                   <h5 className="text-xs font-medium mb-1 text-muted-foreground">
                                     Arguments:
                                   </h5>
-                                  <pre className="bg-background/80 p-2 rounded-md text-xs overflow-auto">
+                                  <pre className="bg-background/80 p-2 rounded-md text-xs overflow-auto whitespace-pre-wrap break-words max-w-[450px]">
                                     {JSON.stringify(
                                       toolInvocation.args,
                                       null,
@@ -342,13 +342,22 @@ export default function Chat() {
                                     <h5 className="text-xs font-medium mb-1 text-muted-foreground">
                                       Result:
                                     </h5>
-                                    <pre className="bg-background/80 p-2 rounded-md text-xs overflow-auto">
-                                      {JSON.stringify(
-                                        toolInvocation.result,
-                                        null,
-                                        2
-                                      )}
-                                    </pre>
+                                    <pre className="bg-background/80 p-2 rounded-md text-xs overflow-auto whitespace-pre-wrap break-words max-w-[450px]">
+{(() => {
+  const result = toolInvocation.result;
+  if (typeof result === 'object' && result.content) {
+    return result.content
+      .map((item: { type: string; text: string }) => {
+        if (item.type === 'text' && item.text.startsWith('\n~ Page URL:')) {
+          const lines = item.text.split('\n').filter(Boolean);
+          return lines.map((line: string) => `- ${line.replace('\n~ ', '')}`).join('\n');
+        }
+        return item.text;
+      })
+      .join('\n');
+  }
+  return JSON.stringify(result, null, 2);
+})()}</pre>
                                   </div>
                                 )}
                               </Card>

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -22,6 +22,7 @@ import {
   Robot,
   Sun,
   Trash,
+  CaretDown,
 } from "@phosphor-icons/react";
 
 // List of tools that require human confirmation
@@ -266,6 +267,7 @@ export default function Chat() {
                             const needsConfirmation = toolsRequiringConfirmation.includes(
                               toolInvocation.toolName as keyof typeof tools
                             );
+                            const [isExpanded, setIsExpanded] = useState(true);
 
                             // Skip rendering the card in debug mode
                             if (showDebug) return null;
@@ -276,73 +278,86 @@ export default function Chat() {
                                 key={i}
                                 className={`p-4 my-3 w-full max-w-[500px] rounded-md bg-neutral-100 dark:bg-neutral-900 ${
                                   needsConfirmation ? "" : "border-[#F48120]/30"
-                                } max-h-[200px] overflow-y-auto`}
+                                } overflow-hidden`}
                               >
-                                <div className="flex items-center gap-2 mb-3">
-                                  <div className={`${needsConfirmation ? "bg-[#F48120]/10" : "bg-[#F48120]/5"} p-1.5 rounded-full flex-shrink-0`}>
-                                    <Robot
-                                      size={16}
-                                      className="text-[#F48120]"
-                                    />
-                                  </div>
-                                  <h4 className="font-medium flex items-center gap-2">
-                                    {toolInvocation.toolName}
-                                    {!needsConfirmation && toolInvocation.state === "result" && (
-                                      <span className="text-xs text-[#F48120]/70">✓ Completed</span>
-                                    )}
-                                  </h4>
-                                </div>
-
-                                <div className="mb-3">
-                                  <h5 className="text-xs font-medium mb-1 text-muted-foreground">
-                                    Arguments:
-                                  </h5>
-                                  <pre className="bg-background/80 p-2 rounded-md text-xs overflow-auto whitespace-pre-wrap break-words max-w-[450px]">
-                                    {JSON.stringify(
-                                      toolInvocation.args,
-                                      null,
-                                      2
-                                    )}
-                                  </pre>
-                                </div>
-
-                                {needsConfirmation && toolInvocation.state === "call" && (
-                                  <div className="flex gap-2 justify-end">
-                                    <Button
-                                      variant="primary"
-                                      size="sm"
-                                      onClick={() =>
-                                        addToolResult({
-                                          toolCallId,
-                                          result: APPROVAL.NO,
-                                        })
-                                      }
-                                    >
-                                      Reject
-                                    </Button>
-                                    <Tooltip content={"Accept action"}>
-                                      <Button
-                                        variant="primary"
-                                        size="sm"
-                                        onClick={() =>
-                                          addToolResult({
-                                            toolCallId,
-                                            result: APPROVAL.YES,
-                                          })
-                                        }
+                                {(() => {
+                                  return (
+                                    <>
+                                      <button 
+                                        type="button"
+                                        onClick={() => setIsExpanded(!isExpanded)}
+                                        className="w-full flex items-center gap-2 cursor-pointer"
                                       >
-                                        Approve
-                                      </Button>
-                                    </Tooltip>
-                                  </div>
-                                )}
+                                        <div className={`${needsConfirmation ? "bg-[#F48120]/10" : "bg-[#F48120]/5"} p-1.5 rounded-full flex-shrink-0`}>
+                                          <Robot
+                                            size={16}
+                                            className="text-[#F48120]"
+                                          />
+                                        </div>
+                                        <h4 className="font-medium flex items-center gap-2 flex-1 text-left">
+                                          {toolInvocation.toolName}
+                                          {!needsConfirmation && toolInvocation.state === "result" && (
+                                            <span className="text-xs text-[#F48120]/70">✓ Completed</span>
+                                          )}
+                                        </h4>
+                                        <CaretDown 
+                                          size={16} 
+                                          className={`text-muted-foreground transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+                                        />
+                                      </button>
 
-                                {!needsConfirmation && toolInvocation.state === "result" && (
-                                  <div className="mt-3 border-t border-[#F48120]/10 pt-3">
-                                    <h5 className="text-xs font-medium mb-1 text-muted-foreground">
-                                      Result:
-                                    </h5>
-                                    <pre className="bg-background/80 p-2 rounded-md text-xs overflow-auto whitespace-pre-wrap break-words max-w-[450px]">
+                                      <div className={`transition-all duration-200 ${isExpanded ? 'max-h-[200px] opacity-100 mt-3' : 'max-h-0 opacity-0 overflow-hidden'}`}>
+                                        <div className="overflow-y-auto" style={{ maxHeight: isExpanded ? '180px' : '0px' }}>
+                                          <div className="mb-3">
+                                            <h5 className="text-xs font-medium mb-1 text-muted-foreground">
+                                              Arguments:
+                                            </h5>
+                                            <pre className="bg-background/80 p-2 rounded-md text-xs overflow-auto whitespace-pre-wrap break-words max-w-[450px]">
+                                              {JSON.stringify(
+                                                toolInvocation.args,
+                                                null,
+                                                2
+                                              )}
+                                            </pre>
+                                          </div>
+
+                                          {needsConfirmation && toolInvocation.state === "call" && (
+                                            <div className="flex gap-2 justify-end">
+                                              <Button
+                                                variant="primary"
+                                                size="sm"
+                                                onClick={() =>
+                                                  addToolResult({
+                                                    toolCallId,
+                                                    result: APPROVAL.NO,
+                                                  })
+                                                }
+                                              >
+                                                Reject
+                                              </Button>
+                                              <Tooltip content={"Accept action"}>
+                                                <Button
+                                                  variant="primary"
+                                                  size="sm"
+                                                  onClick={() =>
+                                                    addToolResult({
+                                                      toolCallId,
+                                                      result: APPROVAL.YES,
+                                                    })
+                                                  }
+                                                >
+                                                  Approve
+                                                </Button>
+                                              </Tooltip>
+                                            </div>
+                                          )}
+
+                                          {!needsConfirmation && toolInvocation.state === "result" && (
+                                            <div className="mt-3 border-t border-[#F48120]/10 pt-3">
+                                              <h5 className="text-xs font-medium mb-1 text-muted-foreground">
+                                                Result:
+                                              </h5>
+                                              <pre className="bg-background/80 p-2 rounded-md text-xs overflow-auto whitespace-pre-wrap break-words max-w-[450px]">
 {(() => {
   const result = toolInvocation.result;
   if (typeof result === 'object' && result.content) {
@@ -358,8 +373,13 @@ export default function Chat() {
   }
   return JSON.stringify(result, null, 2);
 })()}</pre>
-                                  </div>
-                                )}
+                                            </div>
+                                          )}
+                                        </div>
+                                      </div>
+                                    </>
+                                  );
+                                })()}
                               </Card>
                             );
                           }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -10,7 +10,6 @@ import { Card } from "@/components/card/Card";
 import { Input } from "@/components/input/Input";
 import { Avatar } from "@/components/avatar/Avatar";
 import { Toggle } from "@/components/toggle/Toggle";
-import { Tooltip } from "@/components/tooltip/Tooltip";
 import { MemoizedMarkdown } from "./components/memoized-markdown";
 import { ToolInvocationCard } from "@/components/tool-invocation-card/ToolInvocationCard";
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -30,6 +30,134 @@ const toolsRequiringConfirmation: (keyof typeof tools)[] = [
   "getWeatherInformation",
 ];
 
+interface ToolInvocation {
+  toolName: string;
+  toolCallId: string;
+  state: 'call' | 'result' | 'partial-call';
+  step?: number;
+  args: Record<string, unknown>;
+  result?: {
+    content?: Array<{ type: string; text: string }>;
+  };
+}
+
+function ToolInvocationCard({ 
+  toolInvocation, 
+  toolCallId, 
+  needsConfirmation, 
+  addToolResult 
+}: { 
+  toolInvocation: ToolInvocation;
+  toolCallId: string;
+  needsConfirmation: boolean;
+  addToolResult: (args: { toolCallId: string; result: string }) => void;
+}) {
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  return (
+    <Card
+      className={`p-4 my-3 w-full max-w-[500px] rounded-md bg-neutral-100 dark:bg-neutral-900 ${
+        needsConfirmation ? "" : "border-[#F48120]/30"
+      } overflow-hidden`}
+    >
+      <button 
+        type="button"
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="w-full flex items-center gap-2 cursor-pointer"
+      >
+        <div className={`${needsConfirmation ? "bg-[#F48120]/10" : "bg-[#F48120]/5"} p-1.5 rounded-full flex-shrink-0`}>
+          <Robot
+            size={16}
+            className="text-[#F48120]"
+          />
+        </div>
+        <h4 className="font-medium flex items-center gap-2 flex-1 text-left">
+          {toolInvocation.toolName}
+          {!needsConfirmation && toolInvocation.state === "result" && (
+            <span className="text-xs text-[#F48120]/70">✓ Completed</span>
+          )}
+        </h4>
+        <CaretDown 
+          size={16} 
+          className={`text-muted-foreground transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+        />
+      </button>
+
+      <div className={`transition-all duration-200 ${isExpanded ? 'max-h-[200px] opacity-100 mt-3' : 'max-h-0 opacity-0 overflow-hidden'}`}>
+        <div className="overflow-y-auto" style={{ maxHeight: isExpanded ? '180px' : '0px' }}>
+          <div className="mb-3">
+            <h5 className="text-xs font-medium mb-1 text-muted-foreground">
+              Arguments:
+            </h5>
+            <pre className="bg-background/80 p-2 rounded-md text-xs overflow-auto whitespace-pre-wrap break-words max-w-[450px]">
+              {JSON.stringify(
+                toolInvocation.args,
+                null,
+                2
+              )}
+            </pre>
+          </div>
+
+          {needsConfirmation && toolInvocation.state === "call" && (
+            <div className="flex gap-2 justify-end">
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={() =>
+                  addToolResult({
+                    toolCallId,
+                    result: APPROVAL.NO,
+                  })
+                }
+              >
+                Reject
+              </Button>
+              <Tooltip content={"Accept action"}>
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={() =>
+                    addToolResult({
+                      toolCallId,
+                      result: APPROVAL.YES,
+                    })
+                  }
+                >
+                  Approve
+                </Button>
+              </Tooltip>
+            </div>
+          )}
+
+          {!needsConfirmation && toolInvocation.state === "result" && (
+            <div className="mt-3 border-t border-[#F48120]/10 pt-3">
+              <h5 className="text-xs font-medium mb-1 text-muted-foreground">
+                Result:
+              </h5>
+              <pre className="bg-background/80 p-2 rounded-md text-xs overflow-auto whitespace-pre-wrap break-words max-w-[450px]">
+{(() => {
+  const result = toolInvocation.result;
+  if (typeof result === 'object' && result.content) {
+    return result.content
+      .map((item: { type: string; text: string }) => {
+        if (item.type === 'text' && item.text.startsWith('\n~ Page URL:')) {
+          const lines = item.text.split('\n').filter(Boolean);
+          return lines.map((line: string) => `- ${line.replace('\n~ ', '')}`).join('\n');
+        }
+        return item.text;
+      })
+      .join('\n');
+  }
+  return JSON.stringify(result, null, 2);
+})()}</pre>
+            </div>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
 export default function Chat() {
   const [theme, setTheme] = useState<"dark" | "light">(() => {
     // Check localStorage first, default to dark if not found
@@ -267,120 +395,19 @@ export default function Chat() {
                             const needsConfirmation = toolsRequiringConfirmation.includes(
                               toolInvocation.toolName as keyof typeof tools
                             );
-                            const [isExpanded, setIsExpanded] = useState(true);
 
                             // Skip rendering the card in debug mode
                             if (showDebug) return null;
 
                             return (
-                              <Card
-                                // biome-ignore lint/suspicious/noArrayIndexKey: it's fine here
-                                key={i}
-                                className={`p-4 my-3 w-full max-w-[500px] rounded-md bg-neutral-100 dark:bg-neutral-900 ${
-                                  needsConfirmation ? "" : "border-[#F48120]/30"
-                                } overflow-hidden`}
-                              >
-                                {(() => {
-                                  return (
-                                    <>
-                                      <button 
-                                        type="button"
-                                        onClick={() => setIsExpanded(!isExpanded)}
-                                        className="w-full flex items-center gap-2 cursor-pointer"
-                                      >
-                                        <div className={`${needsConfirmation ? "bg-[#F48120]/10" : "bg-[#F48120]/5"} p-1.5 rounded-full flex-shrink-0`}>
-                                          <Robot
-                                            size={16}
-                                            className="text-[#F48120]"
-                                          />
-                                        </div>
-                                        <h4 className="font-medium flex items-center gap-2 flex-1 text-left">
-                                          {toolInvocation.toolName}
-                                          {!needsConfirmation && toolInvocation.state === "result" && (
-                                            <span className="text-xs text-[#F48120]/70">✓ Completed</span>
-                                          )}
-                                        </h4>
-                                        <CaretDown 
-                                          size={16} 
-                                          className={`text-muted-foreground transition-transform ${isExpanded ? 'rotate-180' : ''}`}
-                                        />
-                                      </button>
-
-                                      <div className={`transition-all duration-200 ${isExpanded ? 'max-h-[200px] opacity-100 mt-3' : 'max-h-0 opacity-0 overflow-hidden'}`}>
-                                        <div className="overflow-y-auto" style={{ maxHeight: isExpanded ? '180px' : '0px' }}>
-                                          <div className="mb-3">
-                                            <h5 className="text-xs font-medium mb-1 text-muted-foreground">
-                                              Arguments:
-                                            </h5>
-                                            <pre className="bg-background/80 p-2 rounded-md text-xs overflow-auto whitespace-pre-wrap break-words max-w-[450px]">
-                                              {JSON.stringify(
-                                                toolInvocation.args,
-                                                null,
-                                                2
-                                              )}
-                                            </pre>
-                                          </div>
-
-                                          {needsConfirmation && toolInvocation.state === "call" && (
-                                            <div className="flex gap-2 justify-end">
-                                              <Button
-                                                variant="primary"
-                                                size="sm"
-                                                onClick={() =>
-                                                  addToolResult({
-                                                    toolCallId,
-                                                    result: APPROVAL.NO,
-                                                  })
-                                                }
-                                              >
-                                                Reject
-                                              </Button>
-                                              <Tooltip content={"Accept action"}>
-                                                <Button
-                                                  variant="primary"
-                                                  size="sm"
-                                                  onClick={() =>
-                                                    addToolResult({
-                                                      toolCallId,
-                                                      result: APPROVAL.YES,
-                                                    })
-                                                  }
-                                                >
-                                                  Approve
-                                                </Button>
-                                              </Tooltip>
-                                            </div>
-                                          )}
-
-                                          {!needsConfirmation && toolInvocation.state === "result" && (
-                                            <div className="mt-3 border-t border-[#F48120]/10 pt-3">
-                                              <h5 className="text-xs font-medium mb-1 text-muted-foreground">
-                                                Result:
-                                              </h5>
-                                              <pre className="bg-background/80 p-2 rounded-md text-xs overflow-auto whitespace-pre-wrap break-words max-w-[450px]">
-{(() => {
-  const result = toolInvocation.result;
-  if (typeof result === 'object' && result.content) {
-    return result.content
-      .map((item: { type: string; text: string }) => {
-        if (item.type === 'text' && item.text.startsWith('\n~ Page URL:')) {
-          const lines = item.text.split('\n').filter(Boolean);
-          return lines.map((line: string) => `- ${line.replace('\n~ ', '')}`).join('\n');
-        }
-        return item.text;
-      })
-      .join('\n');
-  }
-  return JSON.stringify(result, null, 2);
-})()}</pre>
-                                            </div>
-                                          )}
-                                        </div>
-                                      </div>
-                                    </>
-                                  );
-                                })()}
-                              </Card>
+                              <ToolInvocationCard
+                                // biome-ignore lint/suspicious/noArrayIndexKey: using index is safe here as the array is static
+                                key={`${toolCallId}-${i}`}
+                                toolInvocation={toolInvocation}
+                                toolCallId={toolCallId}
+                                needsConfirmation={needsConfirmation}
+                                addToolResult={addToolResult}
+                              />
                             );
                           }
                           return null;

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState, useRef, useCallback, use } from "react";
 import { useAgent } from "agents/react";
 import { useAgentChat } from "agents/ai-react";
 import type { Message } from "@ai-sdk/react";
-import { APPROVAL } from "./shared";
 import type { tools } from "./tools";
 
 // Component imports
@@ -13,6 +12,7 @@ import { Avatar } from "@/components/avatar/Avatar";
 import { Toggle } from "@/components/toggle/Toggle";
 import { Tooltip } from "@/components/tooltip/Tooltip";
 import { MemoizedMarkdown } from "./components/memoized-markdown";
+import { ToolInvocationCard } from "@/components/tool-invocation-card/ToolInvocationCard";
 
 // Icon imports
 import {
@@ -22,141 +22,12 @@ import {
   Robot,
   Sun,
   Trash,
-  CaretDown,
 } from "@phosphor-icons/react";
 
 // List of tools that require human confirmation
 const toolsRequiringConfirmation: (keyof typeof tools)[] = [
   "getWeatherInformation",
 ];
-
-interface ToolInvocation {
-  toolName: string;
-  toolCallId: string;
-  state: 'call' | 'result' | 'partial-call';
-  step?: number;
-  args: Record<string, unknown>;
-  result?: {
-    content?: Array<{ type: string; text: string }>;
-  };
-}
-
-function ToolInvocationCard({ 
-  toolInvocation, 
-  toolCallId, 
-  needsConfirmation, 
-  addToolResult 
-}: { 
-  toolInvocation: ToolInvocation;
-  toolCallId: string;
-  needsConfirmation: boolean;
-  addToolResult: (args: { toolCallId: string; result: string }) => void;
-}) {
-  const [isExpanded, setIsExpanded] = useState(true);
-
-  return (
-    <Card
-      className={`p-4 my-3 w-full max-w-[500px] rounded-md bg-neutral-100 dark:bg-neutral-900 ${
-        needsConfirmation ? "" : "border-[#F48120]/30"
-      } overflow-hidden`}
-    >
-      <button 
-        type="button"
-        onClick={() => setIsExpanded(!isExpanded)}
-        className="w-full flex items-center gap-2 cursor-pointer"
-      >
-        <div className={`${needsConfirmation ? "bg-[#F48120]/10" : "bg-[#F48120]/5"} p-1.5 rounded-full flex-shrink-0`}>
-          <Robot
-            size={16}
-            className="text-[#F48120]"
-          />
-        </div>
-        <h4 className="font-medium flex items-center gap-2 flex-1 text-left">
-          {toolInvocation.toolName}
-          {!needsConfirmation && toolInvocation.state === "result" && (
-            <span className="text-xs text-[#F48120]/70">✓ Completed</span>
-          )}
-        </h4>
-        <CaretDown 
-          size={16} 
-          className={`text-muted-foreground transition-transform ${isExpanded ? 'rotate-180' : ''}`}
-        />
-      </button>
-
-      <div className={`transition-all duration-200 ${isExpanded ? 'max-h-[200px] opacity-100 mt-3' : 'max-h-0 opacity-0 overflow-hidden'}`}>
-        <div className="overflow-y-auto" style={{ maxHeight: isExpanded ? '180px' : '0px' }}>
-          <div className="mb-3">
-            <h5 className="text-xs font-medium mb-1 text-muted-foreground">
-              Arguments:
-            </h5>
-            <pre className="bg-background/80 p-2 rounded-md text-xs overflow-auto whitespace-pre-wrap break-words max-w-[450px]">
-              {JSON.stringify(
-                toolInvocation.args,
-                null,
-                2
-              )}
-            </pre>
-          </div>
-
-          {needsConfirmation && toolInvocation.state === "call" && (
-            <div className="flex gap-2 justify-end">
-              <Button
-                variant="primary"
-                size="sm"
-                onClick={() =>
-                  addToolResult({
-                    toolCallId,
-                    result: APPROVAL.NO,
-                  })
-                }
-              >
-                Reject
-              </Button>
-              <Tooltip content={"Accept action"}>
-                <Button
-                  variant="primary"
-                  size="sm"
-                  onClick={() =>
-                    addToolResult({
-                      toolCallId,
-                      result: APPROVAL.YES,
-                    })
-                  }
-                >
-                  Approve
-                </Button>
-              </Tooltip>
-            </div>
-          )}
-
-          {!needsConfirmation && toolInvocation.state === "result" && (
-            <div className="mt-3 border-t border-[#F48120]/10 pt-3">
-              <h5 className="text-xs font-medium mb-1 text-muted-foreground">
-                Result:
-              </h5>
-              <pre className="bg-background/80 p-2 rounded-md text-xs overflow-auto whitespace-pre-wrap break-words max-w-[450px]">
-{(() => {
-  const result = toolInvocation.result;
-  if (typeof result === 'object' && result.content) {
-    return result.content
-      .map((item: { type: string; text: string }) => {
-        if (item.type === 'text' && item.text.startsWith('\n~ Page URL:')) {
-          const lines = item.text.split('\n').filter(Boolean);
-          return lines.map((line: string) => `- ${line.replace('\n~ ', '')}`).join('\n');
-        }
-        return item.text;
-      })
-      .join('\n');
-  }
-  return JSON.stringify(result, null, 2);
-})()}</pre>
-            </div>
-          )}
-        </div>
-      </div>
-    </Card>
-  );
-}
 
 export default function Chat() {
   const [theme, setTheme] = useState<"dark" | "light">(() => {
@@ -392,9 +263,10 @@ export default function Chat() {
                           if (part.type === "tool-invocation") {
                             const toolInvocation = part.toolInvocation;
                             const toolCallId = toolInvocation.toolCallId;
-                            const needsConfirmation = toolsRequiringConfirmation.includes(
-                              toolInvocation.toolName as keyof typeof tools
-                            );
+                            const needsConfirmation =
+                              toolsRequiringConfirmation.includes(
+                                toolInvocation.toolName as keyof typeof tools
+                              );
 
                             // Skip rendering the card in debug mode
                             if (showDebug) return null;

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -267,6 +267,9 @@ export default function Chat() {
                               toolInvocation.toolName as keyof typeof tools
                             );
 
+                            // Skip rendering the card in debug mode
+                            if (showDebug) return null;
+
                             return (
                               <Card
                                 // biome-ignore lint/suspicious/noArrayIndexKey: it's fine here

--- a/src/components/tool-invocation-card/ToolInvocationCard.tsx
+++ b/src/components/tool-invocation-card/ToolInvocationCard.tsx
@@ -1,0 +1,136 @@
+import { useState } from "react";
+import { Robot, CaretDown } from "@phosphor-icons/react";
+import { Button } from "@/components/button/Button";
+import { Card } from "@/components/card/Card";
+import { Tooltip } from "@/components/tooltip/Tooltip";
+import { APPROVAL } from "@/shared";
+
+interface ToolInvocation {
+  toolName: string;
+  toolCallId: string;
+  state: 'call' | 'result' | 'partial-call';
+  step?: number;
+  args: Record<string, unknown>;
+  result?: {
+    content?: Array<{ type: string; text: string }>;
+  };
+}
+
+interface ToolInvocationCardProps {
+  toolInvocation: ToolInvocation;
+  toolCallId: string;
+  needsConfirmation: boolean;
+  addToolResult: (args: { toolCallId: string; result: string }) => void;
+}
+
+export function ToolInvocationCard({ 
+  toolInvocation, 
+  toolCallId, 
+  needsConfirmation, 
+  addToolResult 
+}: ToolInvocationCardProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  return (
+    <Card
+      className={`p-4 my-3 w-full max-w-[500px] rounded-md bg-neutral-100 dark:bg-neutral-900 ${
+        needsConfirmation ? "" : "border-[#F48120]/30"
+      } overflow-hidden`}
+    >
+      <button 
+        type="button"
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="w-full flex items-center gap-2 cursor-pointer"
+      >
+        <div className={`${needsConfirmation ? "bg-[#F48120]/10" : "bg-[#F48120]/5"} p-1.5 rounded-full flex-shrink-0`}>
+          <Robot
+            size={16}
+            className="text-[#F48120]"
+          />
+        </div>
+        <h4 className="font-medium flex items-center gap-2 flex-1 text-left">
+          {toolInvocation.toolName}
+          {!needsConfirmation && toolInvocation.state === "result" && (
+            <span className="text-xs text-[#F48120]/70">✓ Completed</span>
+          )}
+        </h4>
+        <CaretDown 
+          size={16} 
+          className={`text-muted-foreground transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+        />
+      </button>
+
+      <div className={`transition-all duration-200 ${isExpanded ? 'max-h-[200px] opacity-100 mt-3' : 'max-h-0 opacity-0 overflow-hidden'}`}>
+        <div className="overflow-y-auto" style={{ maxHeight: isExpanded ? '180px' : '0px' }}>
+          <div className="mb-3">
+            <h5 className="text-xs font-medium mb-1 text-muted-foreground">
+              Arguments:
+            </h5>
+            <pre className="bg-background/80 p-2 rounded-md text-xs overflow-auto whitespace-pre-wrap break-words max-w-[450px]">
+              {JSON.stringify(
+                toolInvocation.args,
+                null,
+                2
+              )}
+            </pre>
+          </div>
+
+          {needsConfirmation && toolInvocation.state === "call" && (
+            <div className="flex gap-2 justify-end">
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={() =>
+                  addToolResult({
+                    toolCallId,
+                    result: APPROVAL.NO,
+                  })
+                }
+              >
+                Reject
+              </Button>
+              <Tooltip content={"Accept action"}>
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={() =>
+                    addToolResult({
+                      toolCallId,
+                      result: APPROVAL.YES,
+                    })
+                  }
+                >
+                  Approve
+                </Button>
+              </Tooltip>
+            </div>
+          )}
+
+          {!needsConfirmation && toolInvocation.state === "result" && (
+            <div className="mt-3 border-t border-[#F48120]/10 pt-3">
+              <h5 className="text-xs font-medium mb-1 text-muted-foreground">
+                Result:
+              </h5>
+              <pre className="bg-background/80 p-2 rounded-md text-xs overflow-auto whitespace-pre-wrap break-words max-w-[450px]">
+{(() => {
+  const result = toolInvocation.result;
+  if (typeof result === 'object' && result.content) {
+    return result.content
+      .map((item: { type: string; text: string }) => {
+        if (item.type === 'text' && item.text.startsWith('\n~ Page URL:')) {
+          const lines = item.text.split('\n').filter(Boolean);
+          return lines.map((line: string) => `- ${line.replace('\n~ ', '')}`).join('\n');
+        }
+        return item.text;
+      })
+      .join('\n');
+  }
+  return JSON.stringify(result, null, 2);
+})()}</pre>
+            </div>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+} 

--- a/src/components/tool-invocation-card/ToolInvocationCard.tsx
+++ b/src/components/tool-invocation-card/ToolInvocationCard.tsx
@@ -29,7 +29,7 @@ export function ToolInvocationCard({
   needsConfirmation, 
   addToolResult 
 }: ToolInvocationCardProps) {
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(true);
 
   return (
     <Card
@@ -112,21 +112,21 @@ export function ToolInvocationCard({
                 Result:
               </h5>
               <pre className="bg-background/80 p-2 rounded-md text-xs overflow-auto whitespace-pre-wrap break-words max-w-[450px]">
-{(() => {
-  const result = toolInvocation.result;
-  if (typeof result === 'object' && result.content) {
-    return result.content
-      .map((item: { type: string; text: string }) => {
-        if (item.type === 'text' && item.text.startsWith('\n~ Page URL:')) {
-          const lines = item.text.split('\n').filter(Boolean);
-          return lines.map((line: string) => `- ${line.replace('\n~ ', '')}`).join('\n');
-        }
-        return item.text;
-      })
-      .join('\n');
-  }
-  return JSON.stringify(result, null, 2);
-})()}</pre>
+                {(() => {
+                const result = toolInvocation.result;
+                if (typeof result === 'object' && result.content) {
+                    return result.content
+                    .map((item: { type: string; text: string }) => {
+                        if (item.type === 'text' && item.text.startsWith('\n~ Page URL:')) {
+                        const lines = item.text.split('\n').filter(Boolean);
+                        return lines.map((line: string) => `- ${line.replace('\n~ ', '')}`).join('\n');
+                        }
+                        return item.text;
+                    })
+                    .join('\n');
+                }
+                return JSON.stringify(result, null, 2);
+                })()}</pre>
             </div>
           )}
         </div>

--- a/src/components/tool-invocation-card/ToolInvocationCard.tsx
+++ b/src/components/tool-invocation-card/ToolInvocationCard.tsx
@@ -8,7 +8,7 @@ import { APPROVAL } from "@/shared";
 interface ToolInvocation {
   toolName: string;
   toolCallId: string;
-  state: 'call' | 'result' | 'partial-call';
+  state: "call" | "result" | "partial-call";
   step?: number;
   args: Record<string, unknown>;
   result?: {
@@ -23,11 +23,11 @@ interface ToolInvocationCardProps {
   addToolResult: (args: { toolCallId: string; result: string }) => void;
 }
 
-export function ToolInvocationCard({ 
-  toolInvocation, 
-  toolCallId, 
-  needsConfirmation, 
-  addToolResult 
+export function ToolInvocationCard({
+  toolInvocation,
+  toolCallId,
+  needsConfirmation,
+  addToolResult,
 }: ToolInvocationCardProps) {
   const [isExpanded, setIsExpanded] = useState(true);
 
@@ -37,16 +37,15 @@ export function ToolInvocationCard({
         needsConfirmation ? "" : "border-[#F48120]/30"
       } overflow-hidden`}
     >
-      <button 
+      <button
         type="button"
         onClick={() => setIsExpanded(!isExpanded)}
         className="w-full flex items-center gap-2 cursor-pointer"
       >
-        <div className={`${needsConfirmation ? "bg-[#F48120]/10" : "bg-[#F48120]/5"} p-1.5 rounded-full flex-shrink-0`}>
-          <Robot
-            size={16}
-            className="text-[#F48120]"
-          />
+        <div
+          className={`${needsConfirmation ? "bg-[#F48120]/10" : "bg-[#F48120]/5"} p-1.5 rounded-full flex-shrink-0`}
+        >
+          <Robot size={16} className="text-[#F48120]" />
         </div>
         <h4 className="font-medium flex items-center gap-2 flex-1 text-left">
           {toolInvocation.toolName}
@@ -54,24 +53,25 @@ export function ToolInvocationCard({
             <span className="text-xs text-[#F48120]/70">✓ Completed</span>
           )}
         </h4>
-        <CaretDown 
-          size={16} 
-          className={`text-muted-foreground transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+        <CaretDown
+          size={16}
+          className={`text-muted-foreground transition-transform ${isExpanded ? "rotate-180" : ""}`}
         />
       </button>
 
-      <div className={`transition-all duration-200 ${isExpanded ? 'max-h-[200px] opacity-100 mt-3' : 'max-h-0 opacity-0 overflow-hidden'}`}>
-        <div className="overflow-y-auto" style={{ maxHeight: isExpanded ? '180px' : '0px' }}>
+      <div
+        className={`transition-all duration-200 ${isExpanded ? "max-h-[200px] opacity-100 mt-3" : "max-h-0 opacity-0 overflow-hidden"}`}
+      >
+        <div
+          className="overflow-y-auto"
+          style={{ maxHeight: isExpanded ? "180px" : "0px" }}
+        >
           <div className="mb-3">
             <h5 className="text-xs font-medium mb-1 text-muted-foreground">
               Arguments:
             </h5>
             <pre className="bg-background/80 p-2 rounded-md text-xs overflow-auto whitespace-pre-wrap break-words max-w-[450px]">
-              {JSON.stringify(
-                toolInvocation.args,
-                null,
-                2
-              )}
+              {JSON.stringify(toolInvocation.args, null, 2)}
             </pre>
           </div>
 
@@ -113,24 +113,32 @@ export function ToolInvocationCard({
               </h5>
               <pre className="bg-background/80 p-2 rounded-md text-xs overflow-auto whitespace-pre-wrap break-words max-w-[450px]">
                 {(() => {
-                const result = toolInvocation.result;
-                if (typeof result === 'object' && result.content) {
+                  const result = toolInvocation.result;
+                  if (typeof result === "object" && result.content) {
                     return result.content
-                    .map((item: { type: string; text: string }) => {
-                        if (item.type === 'text' && item.text.startsWith('\n~ Page URL:')) {
-                        const lines = item.text.split('\n').filter(Boolean);
-                        return lines.map((line: string) => `- ${line.replace('\n~ ', '')}`).join('\n');
+                      .map((item: { type: string; text: string }) => {
+                        if (
+                          item.type === "text" &&
+                          item.text.startsWith("\n~ Page URL:")
+                        ) {
+                          const lines = item.text.split("\n").filter(Boolean);
+                          return lines
+                            .map(
+                              (line: string) => `- ${line.replace("\n~ ", "")}`
+                            )
+                            .join("\n");
                         }
                         return item.text;
-                    })
-                    .join('\n');
-                }
-                return JSON.stringify(result, null, 2);
-                })()}</pre>
+                      })
+                      .join("\n");
+                  }
+                  return JSON.stringify(result, null, 2);
+                })()}
+              </pre>
             </div>
           )}
         </div>
       </div>
     </Card>
   );
-} 
+}


### PR DESCRIPTION
I think it is a great feature if we can see the exact tool that was invoked with the request. For example Cursor and Claude Destkop is doing this. So I implemented this feature. It is not visible in debug mode, because we have all the information that we need there.
Refer to these screenshots about the functionality:
![Képernyőfotó 2025-04-29 - 18 52 38](https://github.com/user-attachments/assets/7210c673-2cd0-4869-947b-a8e76ec47501)
![Képernyőfotó 2025-04-29 - 18 52 58](https://github.com/user-attachments/assets/7d11a2f1-cb7e-4087-88f2-874501e74238)

The card can be scrollable.
With this pull request I intend to solve [THIS](https://github.com/cloudflare/agents-starter/issues/67) bug.
