### PR TITLE
Add stop button to Chat component for interrupting message generation

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -21,6 +21,7 @@ import {
   Sun,
   Trash,
   PaperPlaneTilt,
+  Stop,
 } from "@phosphor-icons/react";
 
 // List of tools that require human confirmation
@@ -77,6 +78,8 @@ export default function Chat() {
     handleSubmit: handleAgentSubmit,
     addToolResult,
     clearHistory,
+    isLoading,
+    stop,
   } = useAgentChat({
     agent,
     maxSteps: 5,
@@ -342,13 +345,25 @@ export default function Chat() {
                 style={{ height: textareaHeight }}
               />
               <div className="absolute bottom-0 right-0 p-2 w-fit flex flex-row justify-end">
-                <button
-                  type="submit"
-                  className="inline-flex items-center cursor-pointer justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 rounded-full p-1.5 h-fit border border-neutral-200 dark:border-neutral-800"
-                  disabled={pendingToolCallConfirmation || !agentInput.trim()}
-                >
-                  <PaperPlaneTilt size={16} />
-                </button>
+                {isLoading ? (
+                  <button
+                    type="button"
+                    onClick={stop}
+                    className="inline-flex items-center cursor-pointer justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 rounded-full p-1.5 h-fit border border-neutral-200 dark:border-neutral-800"
+                    aria-label="Stop generation"
+                  >
+                    <Stop size={16} />
+                  </button>
+                ) : (
+                  <button
+                    type="submit"
+                    className="inline-flex items-center cursor-pointer justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 rounded-full p-1.5 h-fit border border-neutral-200 dark:border-neutral-800"
+                    disabled={pendingToolCallConfirmation || !agentInput.trim()}
+                    aria-label="Send message"
+                  >
+                    <PaperPlaneTilt size={16} />
+                  </button>
+                )}
               </div>
             </div>
           </div>


### PR DESCRIPTION
This is the follow up implementation for [THIS](https://github.com/cloudflare/agents-starter/issues/69) feature idea. The underlying agents-sdk needed to be fixed by @brettimus [here](https://github.com/brettimus/agents/commit/32002ebebc40acdbff0dc167db0a6149f7fa1a54), thanks for that!

Here is a screenshot for reference:
![Képernyőfotó 2025-05-06 - 11 41 49](https://github.com/user-attachments/assets/5a229b4e-e8bf-4d4e-a32c-47627bde526e)
