### PR TITLE
use npx command to start with template

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A starter template for building AI-powered chat agents using Cloudflare's Agent 
 1. Create a new project:
 
 ```bash
-npx create-cloudflare . --template cloudflare/agents-starter
+npx create-cloudflare@latest --template cloudflare/agents-starter
 ```
 
 2. Install dependencies:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A starter template for building AI-powered chat agents using Cloudflare's Agent 
 1. Create a new project:
 
 ```bash
-npm create cloudflare@latest -- --template cloudflare/agents-starter
+npx create-cloudflare . --template cloudflare/agents-starter
 ```
 
 2. Install dependencies:


### PR DESCRIPTION
`npm create` on Powershell doesn't work with additional args like on bash:

```bash
$: npm create cloudflare@latest -- --template cloudflare/agents-starter
npm warn "cloudflare/agents-starter" is being parsed as a normal command line argument.
npm warn Unknown cli config "--template". This will stop working in the next major version of npm.
``` 

This was fixed yesterday by the npm team: https://github.com/npm/cli/issues/3136#issuecomment-2873976076

But, while they don't release it in the LTS, other people can have the same problem.