### PR TITLE
Improve comments and README for adding tools which require approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ export const executions = {
 Tools can be configured in two ways:
 
 1. With an `execute` function for automatic execution
-2. Without an `execute` function, requiring confirmation and using the `executions` object to handle the confirmed action
+2. Without an `execute` function, requiring confirmation and using the `executions` object to handle the confirmed action. NOTE: The keys in `executions` should match `toolsRequiringConfirmation` in `app.tsx`.
 
 ### Use a different AI model provider
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -25,6 +25,7 @@ import {
 } from "@phosphor-icons/react";
 
 // List of tools that require human confirmation
+// NOTE: this should match the keys in the executions object in tools.ts
 const toolsRequiringConfirmation: (keyof typeof tools)[] = [
   "getWeatherInformation",
 ];

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -125,6 +125,7 @@ export const tools = {
  * Implementation of confirmation-required tools
  * This object contains the actual logic for tools that need human approval
  * Each function here corresponds to a tool above that doesn't have an execute function
+ * NOTE: keys below should match toolsRequiringConfirmation in app.tsx
  */
 export const executions = {
   getWeatherInformation: async ({ city }: { city: string }) => {


### PR DESCRIPTION
I struggled to figure out why confimation UI for new tools which require approval did not work when the tools were added to tools.ts. I thought the reason might be in the LLM treatment of the tool or its parameters, but it turned out to be the fact that those tool keys also had to be added to the client code in app.ts.

This PR simply documents the current hardwired behavior in the README and with comments in the 2 files.

It would nice to improve the implementation to support MCP tools with approval as well.