### PR TITLE
fixed tools that require confirmation

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,13 +54,16 @@ export async function processToolCalls<Tools extends ToolSet>({
             ""
           ) as keyof typeof executions;
 
-          // Only process tools that require confirmation (are in executions object) and are in 'input-available' state
-          if (!(toolName in executions) || part.state !== "input-available")
+          // Only process tools that require confirmation (are in executions object) and are in 'input-available' state and not yet approved
+          if (
+            (!(toolName in executions) || part.state !== "input-available") &&
+            part.output !== APPROVAL.YES
+          )
             return part;
 
           let result: unknown;
 
-          if (part.input === APPROVAL.YES) {
+          if (part.output === APPROVAL.YES) {
             // User approved the tool execution
             if (!isValidToolName(toolName, executions)) {
               return part;
@@ -75,7 +78,7 @@ export async function processToolCalls<Tools extends ToolSet>({
             } else {
               result = "Error: No execute function found on tool";
             }
-          } else if (part.input === APPROVAL.NO) {
+          } else if (part.output === APPROVAL.NO) {
             result = "Error: User denied access to tool execution";
           } else {
             // If no approval input yet, leave the part as-is for user interaction


### PR DESCRIPTION
Added check for confirmation approval, the confirmation message is not in part.output not part.input. Also added a check to not skip over parts that have output, since the confirmation is now in the output.

Fixes #113